### PR TITLE
Make sure the style guide is always accessible to all users

### DIFF
--- a/app/_config/theme.yml
+++ b/app/_config/theme.yml
@@ -26,3 +26,13 @@ SilverStripe\LoginForms\EnablerExtension:
     - '$default'
     - 'bambusa'
     - 'starter'
+
+---
+Name: bambusa-simplestyleguide
+After: '#simplestyleguide'
+---
+# Move the style guide on a different URL segment
+SilverStripe\Control\Director:
+  rules:
+    '_styleguide': false
+    'styleguide': SilverStripe\Controllers\SimpleStyleguideController

--- a/app/_config/theme.yml
+++ b/app/_config/theme.yml
@@ -34,5 +34,5 @@ After: '#simplestyleguide'
 # Move the style guide on a different URL segment
 SilverStripe\Control\Director:
   rules:
-    '_styleguide': false
+    '_styleguide': '->styleguide'
     'styleguide': SilverStripe\Controllers\SimpleStyleguideController

--- a/app/src/Controllers/SimpleStyleguideController.php
+++ b/app/src/Controllers/SimpleStyleguideController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace SilverStripe\Controllers;
+
+use BenManu\SimpleStyleguide\SimpleStyleguideController as BenSimpleStyleguideController;
+use SilverStripe\CMS\Controllers\ModelAsController;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\View\Requirements;
+use SilverStripe\Subsites\Model\Subsite;
+
+/**
+ * Overrides `BenManu\SimpleStyleguide\SimpleStyleguideController` so we can allow non-dev users to access the style
+ * guide.
+ */
+class SimpleStyleguideController extends BenSimpleStyleguideController
+{
+
+    private static $url_segment = 'styleguide';
+
+    /**
+     * @note This function was copied from BenSimpleStyleguideController. We commented-out the access control logic so
+     * all users can see the Style guide all the time.
+     * @return \SilverStripe\ORM\FieldType\DBHTMLText
+     */
+    public function index()
+    {
+        // This block was in the original SimpleStyleguideController
+        //if (!Director::isDev() && !Permission::check('ADMIN')) {
+        //    return Security::permissionFailure();
+        //}
+
+        // If the subsite module is installed then set the theme based on the current subsite
+        if (class_exists('Subsite') && Subsite::currentSubsite()) {
+            Config::inst()->update('SSViewer', 'theme', Subsite::currentSubsite()->Theme);
+        }
+
+        $page = SiteTree::get()->first();
+        $controller = ModelAsController::controller_for($page);
+        $controller->init();
+
+        // requirements
+        Requirements::css('benmanu/silverstripe-simple-styleguide: css/styleguide.css');
+        Requirements::javascript('benmanu/silverstripe-simple-styleguide: js/styleguide.js');
+
+        return $controller
+            ->customise($this->getStyleGuideData())
+            ->renderWith(['SimpleStyleguideController', 'Page']);
+    }
+}

--- a/app/src/Controllers/SimpleStyleguideController.php
+++ b/app/src/Controllers/SimpleStyleguideController.php
@@ -34,7 +34,7 @@ class SimpleStyleguideController extends BenSimpleStyleguideController
             Config::inst()->update('SSViewer', 'theme', Subsite::currentSubsite()->Theme);
         }
 
-        $page = SiteTree::get()->first();
+        $page = SiteTree::singleton();
         $controller = ModelAsController::controller_for($page);
         $controller->init();
 


### PR DESCRIPTION
This overrides the style guide controller with our own custom implementation that make the style guide publicly accessible on live environments.

# Parent issue
* https://github.com/silverstripe/bambusa-theme/issues/3