### PR TITLE
ENH / Xenial, add Travis ENV vars to docker image 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
-dist: trusty
+dist: xenial
 services:
   - mysql
   - docker
+  - xvfb
 
 cache:
   directories:
@@ -12,6 +13,8 @@ addons:
   apt:
     packages:
       - tidy
+      - chromium-chromedriver
+      - chromium-browser
 
 matrix:
   fast_finish: true
@@ -21,16 +24,16 @@ matrix:
 env:
   global:
     - DB=MYSQL
-    - DISPLAY=":99"
-    - XVFBARGS=":99 -ac -screen 0 1024x768x16"
     - SS_BASE_URL="http://localhost:8080/"
     - SS_ENVIRONMENT_TYPE="dev"
     - SS_BAMBUSA_SUPPRESS_MODAL=1
 
 install:
-  - sudo apt-get update
-  - sudo apt-get install chromium-chromedriver
-  - export PATH=/usr/lib/chromium-browser/:~/.composer/vendor/bin:$PATH
+  # this would conflict with our chromium-browser installation
+  # and its version is incompatible with chromium-chromedriver
+  - sudo apt-get remove --purge google-chrome-stable
+
+  - export PATH=~/.composer/vendor/bin:$PATH
   - pecl channel-update pecl.php.net
   - phpenv rehash
   - phpenv config-rm xdebug.ini || true
@@ -41,6 +44,8 @@ install:
   - composer require --no-update -- silverstripe/serve:^2;
   - composer update --prefer-source
 
+  - composer show
+
   - mkdir artifacts; cp composer.lock artifacts/
 
 
@@ -48,9 +53,8 @@ script:
   - vendor/bin/phpunit --testsuite bambusa
   - composer run-script lint
   - phpdbg -qrr vendor/bin/phpunit --testsuite bambusa --coverage-clover=coverage.xml
-  - sh -e /etc/init.d/xvfb start
   - vendor/bin/serve --bootstrap-file vendor/silverstripe/cms/tests/behat/serve-bootstrap.php &> artifacts/serve.log &
-  - sleep 3; chromedriver > artifacts/chromedriver.log 2>&1 &
+  - chromedriver --port=9515 --whitelisted-ips='127.0.0.1' > artifacts/chromedriver.log 2>&1 &
   - vendor/bin/behat admin
 
 deploy:

--- a/app/_config/raygun.yml
+++ b/app/_config/raygun.yml
@@ -3,6 +3,7 @@ Name: raygun-handler
 ---
 SilverStripe\Core\Injector\Injector:
   SilverStripe\Raygun\RaygunHandler:
+    class: SilverStripe\Bambusa\Logging\RaygunHandler
     constructor:
       client: '%$Raygun4php\RaygunClient'
       level: 'debug'

--- a/app/src/Logging/RaygunHandler.php
+++ b/app/src/Logging/RaygunHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SilverStripe\Bambusa\Logging;
+
+use SilverStripe\Core\Environment;
+use SilverStripe\Raygun;
+
+/**
+ * Custom RaygunHandler that adds SS_TRAVIS_* variables to Raygun CustomUserData
+ */
+class RaygunHandler extends Raygun\RaygunHandler
+{
+    protected function write(array $record)
+    {
+        if (isset($record['formatted']['custom_data'])) {
+            $customData = [];
+
+            foreach (array_merge($_ENV, $_SERVER, Environment::getVariables()['env']) as $key => $val) {
+                $prefix = 'SS_TRAVIS_';
+                if (substr($key, 0, strlen($prefix)) !== $prefix) {
+                    continue;
+                }
+
+                $customData[$key] = $val;
+            }
+
+            $record['formatted']['custom_data'] = array_merge(
+                $record['formatted']['custom_data'],
+                $customData
+            );
+        }
+
+        return parent::write($record);
+    }
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,6 +38,20 @@ ENV APACHE_RUN_USER www-data
 ENV APACHE_RUN_GROUP www-data
 EXPOSE 80
 
+ARG travis_commit_id
+ARG travis_build_num
+ARG travis_build_url
+ARG travis_job_num
+ARG travis_job_url
+ARG travis_docker_image_tag
+
+ENV SS_TRAVIS_COMMIT_ID ${travis_commit_id:-undefined}
+ENV SS_TRAVIS_BUILD_NUM ${travis_build_num:-undefined}
+ENV SS_TRAVIS_BUILD_URL ${travis_build_url:-undefined}
+ENV SS_TRAVIS_JOB_NUM ${travis_job_num:-undefined}
+ENV SS_TRAVIS_JOB_URL ${travis_job_url:-undefined}
+ENV SS_TRAVIS_DOCKER_IMAGE_TAG ${travis_docker_image_tag:-undefined}
+
 WORKDIR /var/www/html
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -11,14 +11,26 @@ fi
 
 DOCKER_SCRIPTS_BASE_DIR=$(dirname $(readlink -f "$0"))
 APPLICATION_BASE_DIR=$(dirname "$DOCKER_SCRIPTS_BASE_DIR")
+VERSION=$(date +%s)
+TARGET_IMAGE="$3"
 
 rm -rf "$APPLICATION_BASE_DIR/vendor";
 cd $APPLICATION_BASE_DIR;
-composer update --ignore-platform-reqs --prefer-dist --no-dev --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
-docker build --no-cache -t "bambusa:new" -f "$DOCKER_SCRIPTS_BASE_DIR/Dockerfile" "$APPLICATION_BASE_DIR"
 
-VERSION=$(date +%s)
-TARGET_IMAGE="$3"
+composer update --ignore-platform-reqs --prefer-dist --no-dev --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
+composer show # logging for CI
+
+docker build \
+  --no-cache \
+  --build-arg "travis_commit_id=$TRAVIS_COMMIT" \
+  --build-arg "travis_build_num=$TRAVIS_BUILD_NUMBER" \
+  --build-arg "travis_build_url=$TRAVIS_BUILD_WEB_URL" \
+  --build-arg "travis_job_num=$TRAVIS_JOB_NUMBER" \
+  --build-arg "travis_job_url=$TRAVIS_JOB_WEB_URL" \
+  --build-arg "travis_docker_image_tag=$VERSION" \
+  -t "bambusa:new" \
+  -f "$DOCKER_SCRIPTS_BASE_DIR/Dockerfile"\
+  "$APPLICATION_BASE_DIR"
 
 echo $2 | docker login --password-stdin -u $1
 


### PR DESCRIPTION
- Upgrade Travis distro to Xenial
- Add build info to the docker image (for passing to Raygun)

The point of adding the TravisCI environment variables to the docker image is so those propagate to Raygun logs to facilitate later debugging.