### PR TITLE
Add color picker for banner block

### DIFF
--- a/app/src/Extensions/SiteConfigExtension.php
+++ b/app/src/Extensions/SiteConfigExtension.php
@@ -3,14 +3,46 @@
 
 namespace SilverStripe\Bambusa\Extensions;
 
+use SilverStripe\Colorpicker\Forms\ColorPickerField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\ORM\DataExtension;
 
 class SiteConfigExtension extends DataExtension
 {
+
+    private static $db = [
+        'BannerBlockColor' => 'Varchar(50)',
+    ];
+
+    private static $defaults = [
+        'BannerBlockColor' => 'dark-orange'
+    ];
+
+
     public function updateCMSFields(FieldList $fields)
     {
         $tabSet = $fields->fieldByName('Root');
         $tabSet->removeByName('VulcanSEO');
+
+        $fields->insertBefore(
+            'AccentColor',
+            ColorPickerField::create(
+                'BannerBlockColor',
+                _t(
+                    __CLASS__ . '.BannerBlockColor',
+                    'Banner block color'
+                ),
+                $this->getOwner()->getThemeOptionsExcluding([
+                    'light-grey',
+                    'white',
+                    'default-background',
+                ])
+            )->setDescription(
+                _t(
+                    __CLASS__ . '.BannerBlockColorDescription',
+                    'Affects color of banner block.'
+                )
+            )
+        );
     }
 }


### PR DESCRIPTION
Adds a color picker to choose a custom banner block color in SiteConfig

# Parent issue
* https://github.com/silverstripe/bambusa-theme/issues/9

# Depends on 
* https://github.com/silverstripe/bambusa-theme/pull/24