### PR TITLE
Suppress elemental-bannerblock styles

### DIFF
--- a/app/src/PageController.php
+++ b/app/src/PageController.php
@@ -18,6 +18,8 @@ namespace {
                 Requirements::javascript('app/js/dialog.js', ['defer' => true]);
                 Requirements::css('app/css/dialog.css');
             }
+
+            Requirements::block('silverstripe/elemental-bannerblock:client/dist/styles/frontend-default.css');
         }
 
         /**


### PR DESCRIPTION
The `elemental-bannerblock` are getting in the way of our custom pretty banner block styles.

# Parent issue
* https://github.com/silverstripe/bambusa-theme/issues/9