### PR TITLE
FIX / workaround the bug with mysqli not switching connection_collation

### DIFF
--- a/app/_config/mysite.yml
+++ b/app/_config/mysite.yml
@@ -19,9 +19,9 @@ SilverStripe\Fontpicker\Forms\FontPickerField:
   default_font: metropolis
 SilverStripe\ORM\Connect\MySQLDatabase:
   connection_charset: utf8mb4
-  connection_collation: utf8mb4_unicode_ci
+  connection_collation: utf8mb4_general_ci
   charset: utf8mb4
-  collation: utf8mb4_unicode_ci
+  collation: utf8mb4_general_ci
 Symbiote\AdvancedWorkflow\Actions\NotifyUsersWorkflowAction:
   whitelist_template_variables: true
 SilverStripe\CMS\Model\SiteTree:


### PR DESCRIPTION
Falling back to the default collation since our `MySQLiConnector` implementation doesn't switch `collation_connection` properly due to a bug, which breaks prepared statements that have string parameters bound.