### PR TITLE
Fix EnvVarSnapshot

### DIFF
--- a/app/src/Middleware/EnvVarSnapshotApplicationMiddleware.php
+++ b/app/src/Middleware/EnvVarSnapshotApplicationMiddleware.php
@@ -35,7 +35,8 @@ class EnvVarSnapshotApplicationMiddleware implements HTTPMiddleware
      */
     public function process(HTTPRequest $request, callable $delegate)
     {
-        if (class_exists('mysqli') && Environment::getEnv('SS_DATABASE_CLASS') === 'MySQLDatabase') {
+        $ssDatabaseClass = Environment::getEnv('SS_DATABASE_CLASS');
+        if (class_exists('mysqli') && ($ssDatabaseClass === false || $ssDatabaseClass === 'MySQLDatabase')) {
             try {
                 $connection = new \mysqli(
                     (string)Environment::getEnv('SS_DATABASE_SERVER'),

--- a/app/src/Models/EnvVarSnapshot.php
+++ b/app/src/Models/EnvVarSnapshot.php
@@ -22,6 +22,23 @@ use SilverStripe\ORM\ValidationException;
  */
 class EnvVarSnapshot extends DataObject
 {
+    /**
+     * The list of keys we don't want to put into the database snapshot
+     */
+    const IGNORED_KEYS = [
+        'SS_TRUSTED_PROXY_IPS',
+        'SS_DATABASE_CLASS',
+        'SS_DATABASE_NAME',
+        'SS_DATABASE_PASSWORD',
+        'SS_DATABASE_SERVER',
+        'SS_DATABASE_TIMEZONE',
+        'SS_DATABASE_USERNAME',
+        'SS_ENVIRONMENT_TYPE',
+        'SS_BASE_URL',
+        'SS_DEFAULT_ADMIN_PASSWORD',
+        'SS_DEFAULT_ADMIN_USERNAME'
+    ];
+
     private static $table_name = 'EnvVarSnapshot';
 
     private static $db = [
@@ -65,6 +82,10 @@ class EnvVarSnapshot extends DataObject
     {
         foreach (array_merge($_ENV, $_SERVER, Environment::getVariables()['env']) as $key => $val) {
             if (substr($key, 0, 3) !== 'SS_') {
+                continue;
+            }
+
+            if (in_array($key, static::IGNORED_KEYS)) {
                 continue;
             }
 

--- a/docker/scripts/configure-silverstripe
+++ b/docker/scripts/configure-silverstripe
@@ -9,15 +9,17 @@ fi
 
 set +e
 until nc -z -v -w30 "$SS_DATABASE_SERVER" 3306; do sleep 1; done
+mkdir -p /var/www/html/public/assets || true
+
 set -e
-mkdir -p /var/www/html/public/assets
 chown -R www-data:www-data /var/www/html/public/assets
 gosu www-data php vendor/silverstripe/framework/cli-script.php dev/build
 
 set +e
 until nc -z -v -w30 "$SOLR_SERVER" "$SOLR_PORT"; do sleep 1; done
+mkdir -p "$SOLR_INDEXSTORE_PATH" || true
+
 set -e
-mkdir -p "$SOLR_INDEXSTORE_PATH"
 chown -R www-data:www-data "$SOLR_INDEXSTORE_PATH"
 gosu www-data php vendor/silverstripe/framework/cli-script.php dev/tasks/Solr_Configure
 gosu www-data php vendor/silverstripe/framework/cli-script.php dev/tasks/Solr_Reindex


### PR DESCRIPTION
 - `EnvVarSnapshot` and its ApplicationMiddleware to handle `SS_DATABASE_CLASS` correctly
 - `configure-silverstripe` may be run repeatedly

Fixes https://github.com/silverstripe/bambusa-installer/issues/71
Fixes https://github.com/silverstripe/bambusa-installer/issues/69